### PR TITLE
update to fix maxrect to work with modern libraries.

### DIFF
--- a/maxrect/__init__.py
+++ b/maxrect/__init__.py
@@ -136,9 +136,9 @@ def get_maximal_rectangle(coordinates):
             constraints.append(tl[0] * A1[i] + tl[1] * A2[i] >= B[i])
 
     prob = cvxpy.Problem(obj, constraints)
-    prob.solve(solver=cvxpy.CVXOPT, verbose=False, max_iters=1000, reltol=1e-9)
+    prob.solve()
 
     bottom_left = np.array(bl.value).T * scale
     top_right = np.array(tr.value).T * scale
 
-    return list(bottom_left[0]), list(top_right[0])
+    return bottom_left, top_right


### PR DESCRIPTION
cvxpy is substantially different now. CVXOPT cannot solve the problem, and the default autosolve approach works just fine with convex coordinates. the resolved values have a different shape, so we must return the raw coordinates.